### PR TITLE
Fix use of deprecated curly brace syntax for string offsets

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -160,10 +160,10 @@ class admin_plugin_linkfix extends DokuWiki_Admin_Plugin {
                 $pos  = $instruction[2] - 1;
 
                 while(
-                    $text{$pos} == '[' ||
-                    $text{$pos} == '{' ||
-                    $text{$pos} == ' ' ||
-                    $text{$pos} == "\t"
+                    $text[$pos] == '[' ||
+                    $text[$pos] == '{' ||
+                    $text[$pos] == ' ' ||
+                    $text[$pos] == "\t"
                 ) {
                     $pos++;
                 }


### PR DESCRIPTION
Curly brace syntax has been deprecated with PHP 7.4 (https://wiki.php.net/rfc/deprecate_curly_braces_array_access)